### PR TITLE
Fixed failure to build with promu v0.5.0

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,4 +1,5 @@
-go: 1.10.1
+go:
+    version: 1.10.1
 repository:
     path: github.com/stuartnelson3/passenger_exporter
 build:


### PR DESCRIPTION
Promu requires the go version to be in the version property of go.