### PR TITLE
add group name as label to group queue metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func NewExporter(cmd string, timeout time.Duration) *Exporter {
 		appGroupQueue: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "app_group_queue"),
 			"Number of requests in app group process queues.",
-			[]string{"default"},
+			[]string{"group", "default"},
 			nil,
 		),
 		appProcsSpawning: prometheus.NewDesc(
@@ -166,7 +166,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(e.appQueue, prometheus.GaugeValue, parseFloat(sg.RequestsInQueue), sg.Name)
 		ch <- prometheus.MustNewConstMetric(e.appProcsSpawning, prometheus.GaugeValue, parseFloat(sg.Group.ProcessesSpawning), sg.Name)
 
-		ch <- prometheus.MustNewConstMetric(e.appGroupQueue, prometheus.GaugeValue, parseFloat(sg.Group.GetWaitListSize), sg.Group.Default)
+		ch <- prometheus.MustNewConstMetric(e.appGroupQueue, prometheus.GaugeValue, parseFloat(sg.Group.GetWaitListSize), sg.Group.Name, sg.Group.Default)
 
 		// Update process identifiers map.
 		processIdentifiers = updateProcesses(processIdentifiers, sg.Group.Processes)


### PR DESCRIPTION
In production we had to add a separate queue for passenger healthchecks vs. app healthchecks.  In order to distinguish between the two in metrics we added the group name to metrics as a label.

This has been stable in production for a number of months.

This is in contrast to #9 